### PR TITLE
Add ignore patterns for download_deps artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,17 @@ sdk/python/ragflow_sdk.egg-info/
 huggingface.co/
 nltk_data/
 
+# Downloaded dependencies
+libssl1.1_1.1.1f-1ubuntu2_amd64.deb
+libssl1.1_1.1.1f-1ubuntu2_arm64.deb
+tika-server-standard-3.0.0.jar
+tika-server-standard-3.0.0.jar.md5
+cl100k_base.tiktoken
+chrome-linux64-121-0-6167-85
+chromedriver-linux64-121-0-6167-85
+chrome-linux64.zip
+chromedriver-linux64.zip
+
 # Exclude hash-like temporary files like 9b5ad71b2ce5302211f9c61530b329a4922fc6a4
 *[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*
 .lh/


### PR DESCRIPTION
## Summary
- ignore artifacts downloaded by `download_deps.py`

## Testing
- `pre-commit run --files .gitignore` *(fails: command not found)*